### PR TITLE
Dependency updates; remove rogue print call

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -55,7 +55,7 @@ export LIVE_WORKER_INSTANCES=3
 export LIVE_GUNICORN_INSTANCES=positiveNumber_or_-1_forAllCPUs
 
 ### REDIS CONFIG
-export REDIS_DIST=redis-5.0.5
+export REDIS_DIST=redis-5.0.10
 export REDIS_PORT=6379
 export REDIS_MAX_QUEUE_SIZE=100
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ APScheduler==3.6.0
 asn1crypto==0.24.0
 astropy==3.2.3
 astropy-helpers==3.2.1
+astroquery==0.4.1
 atomicwrites==1.3.0
 beautifulsoup4==4.7.1
 certifi==2019.3.9
@@ -12,7 +13,7 @@ chardet==3.0.4
 Click==7.0
 colorhash==1.0.2
 configparser==3.7.1
-cryptography==2.7
+cryptography==3.2
 cycler==0.10.0
 decorator==4.4.0
 entrypoints==0.3
@@ -43,7 +44,7 @@ pg8000==1.13.1
 Pillow>=6.2.2
 plotly==3.7.1
 psutil>=5.6.6
-psycopg2-binary==2.8.3
+psycopg2-binary==2.8.6
 pycparser==2.19
 pyflakes==2.1.0
 PyMySQL==0.9.3
@@ -72,4 +73,4 @@ werkzeug<=0.16.0
 wrapt==1.11.1
 wheel==0.35.1
 -e git+git://github.com/Small-Bodies-Node/sbsearch.git@v1.1.5#egg=sbsearch
--e git+git://github.com/Small-Bodies-Node/catch.git@v0.5.1#egg=catch
+-e git+git://github.com/Small-Bodies-Node/catch.git@v0.5.3#egg=catch

--- a/src/services/caught.py
+++ b/src/services/caught.py
@@ -38,7 +38,6 @@ def caught(job_id: uuid.UUID) -> List[dict]:
             found.append({})
             for table in row:
                 fields: dict = {}
-                print(dir(type(table)))
                 for k in dir(type(table)):
                     if k.startswith('_'):
                         continue


### PR DESCRIPTION
Add astroquery to requirements and avoid issue installing sbpy

Bump cryptography for security update.

psycopg2-binary==2.8.3 would not install for me, but 2.8.6 is OK.

catch->0.5.3 for skymapper https and sources bugfix.

redis->5.0.10; 5.0.5 does not compile with gcc-10