### PR TITLE
Fix stream format

### DIFF
--- a/services/apis/src/api/stream.py
+++ b/services/apis/src/api/stream.py
@@ -24,10 +24,10 @@ def messages() -> Iterator[str]:
         if len(message) == 0:
             count += 1
             if count > (ENV.STREAM_TIMEOUT // wait):
-                yield ': timeout\n'
+                yield ': timeout\n\n'
                 return
             else:
-                yield ': stayin\' alive\n'
+                yield ': stayin\' alive\n\n'
                 continue
 
         content: bytes
@@ -35,4 +35,4 @@ def messages() -> Iterator[str]:
         data: str = content.get(b'data', b'').decode()
         if data != '':
             count = 0
-            yield f'data: {data}\n'
+            yield f'data: {data}\n\n'


### PR DESCRIPTION
SSE clients won't process any events until a blank line is reached.  So, follow SSE stream messages with two newlines.