### PR TITLE
Enabled Catalina Sky Survey searches.

### DIFF
--- a/services/apis/setup.cfg
+++ b/services/apis/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     rq>=1.1.0
     SQLAlchemy==1.3.*
     swagger-ui-bundle==0.0.9
-    catch>=1.0.0
+    catch>=1.1.0
 include_package_data = True
 
 [options.packages.find]

--- a/services/apis/src/catch_apis/api/openapi.yaml
+++ b/services/apis/src/catch_apis/api/openapi.yaml
@@ -34,6 +34,9 @@ paths:
                 - neat_maui_geodss
                 - skymapper
                 - ps1dr2
+                - catalina_bigelow
+                - catalina_lemmon
+                - catalina_kittpeak
         - name: uncertainty_ellipse
           in: query
           description: Enable searches account for uncertainty ellipse using a polygonal approximation.
@@ -89,6 +92,9 @@ paths:
                             - neat_maui_geodss
                             - skymapper
                             - ps1dr2
+                            - catalina_bigelow
+                            - catalina_lemmon
+                            - catalina_kittpeak
                       uncertainty_ellipse:
                         description: Enable searches account for uncertainty ellipse using a polygonal approximation.
                         type: boolean

--- a/services/apis/src/catch_apis/api/openapi.yaml
+++ b/services/apis/src/catch_apis/api/openapi.yaml
@@ -183,9 +183,41 @@ paths:
                           type: number
                           description: Detection limit, mag.
                           nullable: true
-                        skymapper_image_type:
+                        "css:telescope":
                           type: string
-                          description: "Type of image: Fast Survey, Main Survey, Standard Field."
+                          description: Catalina Sky Survey telescope name.
+                          nullable: true
+                        "ps1:frame_id":
+                          type: integer
+                          description: PanSTARRS 1 survey frame/exposure identifier of the frame associated with this warp.
+                          nullable: true
+                        "ps1:projection_id":
+                          type: integer
+                          description: PanSTARRS 1 projection cell identifier.
+                          nullable: true
+                        "ps1:skycell_id":
+                          type: integer
+                          description: PanSTARRS 1 survey skycell region identifier.
+                          nullable: true
+                        "skymapper:field_id":
+                          type: integer
+                          description: SkyMapper survey field identifier.
+                          nullable: true
+                        "skymapper:image_type":
+                          type: string
+                          description: SkyMapper image type.
+                          enum:
+                            - Shallow Survey
+                            - Main Survey
+                            - Standard Field
+                          nullable: true
+                        "skymapper:sb_mag":
+                          type: number
+                          description: SkyMapper image surface brightness estimate (ABmag).
+                          nullable: true
+                        "skymapper:zpapprox":
+                          type: number
+                          description: SkyMapper approximate photometric zeropoint for the exposure.
                           nullable: true
                         date:
                           type: string

--- a/tests/test_query_moving.py
+++ b/tests/test_query_moving.py
@@ -16,6 +16,7 @@ import pytest
 from sseclient import SSEClient
 
 
+# Only NEAT GEODSS will be searched
 TARGET_EQUIVALENCIES = [
     ('65P', '65P/Gunn'),
     ('C/1995 O1', 'C/1995 O1 (Hale-Bopp)'),
@@ -104,10 +105,11 @@ def _query(target: str, cached: bool, source: Optional[str] = None
 
 @pytest.mark.parametrize('targets', TARGET_EQUIVALENCIES)
 def test_equivalencies(targets: List[str]) -> None:
-    q0 = _query(targets[0], True)[0]['data']
+    source = 'neat_maui_geodss'
+    q0 = _query(targets[0], True, source=source)[0]['data']
     assert len(q0) > 0
     for target in targets[1:]:
-        q = _query(target, True)[0]['data']
+        q = _query(target, True, source=source)[0]['data']
         for a, b in zip(q0, q):
             for k in COMPARE_KEYS:
                 assert a[k] == b[k]

--- a/tests/test_query_moving.py
+++ b/tests/test_query_moving.py
@@ -30,7 +30,6 @@ COMPARE_KEYS = ['airmass', 'date', 'ddec', 'dec', 'delta', 'dra', 'drh',
                 'source_name', 'true_anomaly', 'unc_a', 'unc_b', 'unc_theta',
                 'vangle', 'vmag']
 
-
 # Number of matches updated 2022 Feb 6.  One target for each regex in
 # src/services/query.py, except for the packed designations.
 TARGET_MATCHES = [


### PR DESCRIPTION
Also, be specific about what gets searched by `catch-apis` by default.  The `catch` library will search *all* survey sources by default.  Forcing `catch-apis` to be specific avoids the `catch` library searching data sources that may be in development or otherwise not yet released to the public.  Merge after #23 .