### PR TITLE
Bugfix uncertainty is none 2022.12

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -16,6 +16,7 @@ export WHI="\033[37m"
 #################################
 export PYTHON_3_7_OR_HIGHER='python3'
 export CATCH_LIBS_DIR='.catchlibs'
+export APP_NAME='catch-apis-dev'
 
 #################################
 ### Python Config
@@ -31,7 +32,7 @@ DEBUG=false
 DEPLOYMENT_TIER=LOCAL
 
 ### Gunicorn settings for flask and worker (if =-1 then it's determined by CPU count)
-GUNICORN_APP_NAME='catch-apis-dev'
+GUNICORN_APP_NAME=${APP_NAME}
 GUNICORN_FLASK_INSTANCES=-1
 GUNICORN_WORKER_INSTANCES=-1
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     ".catchlibs/sbsearch",
     ".catchlibs/sbpy"
   ],
-  "restructuredtext.syntaxHighlighting.disabled": true
+  "restructuredtext.syntaxHighlighting.disabled": true,
+  "python.formatting.provider": "autopep8"
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CATCH-APIs v2.1.0
+# CATCH-APIs v2.1.1
 
 An API for the Planetary Data System Small Bodies Node survey data search tool: catch comets and asteroids in wide-field sky survey data.
 
@@ -104,7 +104,7 @@ CATCH-APIs are developed and run using docker. To develop locally:
   - To run everything in prod mode, run `docker-compose -f docker-compose.prod.yml up --build`
 - DB setup:
   - The CATCH tool requires a postgresDB populated with initial data. In previous implementations, this DB was provided as a separate docker container. Now, however, we have separated the DB into its own postgres service on AWS RDS. If you want to develop this code, you therefore need to connect to the development db on our group's AWS instance (contact DWD or MSK for access), or you need to set up your own postgres instance and populate with data (see above).
-- Once everything is running in dev mode, visit http://localhost:5000/ui to see the swagger interface, and in a separate tab open to http://localhost:5000/stream
+- Once everything is running in dev mode, visit <http://localhost:5000/ui> to see the swagger interface, and in a separate tab open to <http://localhost:5000/stream>
 
 ## Adding New Data
 

--- a/requirements.vscode.txt
+++ b/requirements.vscode.txt
@@ -7,7 +7,7 @@ isort==5.5.3
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 more-itertools==8.5.0
-mypy==0.782
+mypy==0.991
 mypy-extensions==0.4.3
 packaging==20.4
 pluggy==0.13.1
@@ -18,6 +18,6 @@ pyparsing==2.4.7
 pytest==6.0.2
 six==1.15.0
 toml==0.10.1
-typed-ast==1.4.1
-typing-extensions==3.7.4.3
+typed-ast==1.5.4
+typing-extensions==4.4.0
 wrapt==1.12.1

--- a/services/apis/requirements.txt
+++ b/services/apis/requirements.txt
@@ -1,14 +1,13 @@
--e git+https://git@github.com/NASA-Planetary-Science/sbpy.git#egg=sbpy
--e git+https://git@github.com/Small-Bodies-Node/sbsearch.git@v2.0.3#egg=sbsearch
+-e git+https://git@github.com/Small-Bodies-Node/sbsearch.git@v2.0.4#egg=sbsearch
 -e git+https://git@github.com/Small-Bodies-Node/catch.git@v1.2.0#egg=catch
-astropy==4.3.1
+astropy==5.1.1
 astroquery>=0.4.5
 connexion==2.9.0
 Flask==1.1.4
 Flask-Cors==3.0.10
 gunicorn==20.0.4
 markupsafe==2.0.1
-numpy==1.19.*
+numpy>=1.20.0
 pds4-tools==1.3
 Pillow==8.4.0
 psycopg2-binary==2.8.6
@@ -16,5 +15,6 @@ python-dotenv==0.19.*
 redis==3.3.8
 requests==2.26.0
 rq==1.1.0
+sbpy>=0.3.0
 SQLAlchemy==1.3.5
 swagger-ui-bundle==0.0.9

--- a/services/apis/src/api/openapi.yaml
+++ b/services/apis/src/api/openapi.yaml
@@ -252,19 +252,16 @@ paths:
                           type: number
                           description: Declination rate of change, arcsec/hr.
                         unc_a:
-                          type: 
-                            - number
-                            - "null"
+                          type: number
+                          nullable: true
                           description: Error ellipse semi-major axis, arcsec.
                         unc_b:
-                          type:
-                            - number
-                            - "null"
+                          type: number
+                          nullable: true
                           description: Error ellipse semi-minor axis, arcsec.
                         unc_theta:
-                          type:
-                            - number
-                            - "null"
+                          type: number
+                          nullable: true
                           description: Error ellipse position angle (E of N), deg.
                         elong:
                           type: number

--- a/services/apis/src/api/openapi.yaml
+++ b/services/apis/src/api/openapi.yaml
@@ -252,13 +252,19 @@ paths:
                           type: number
                           description: Declination rate of change, arcsec/hr.
                         unc_a:
-                          type: number
+                          type: 
+                            - number
+                            - "null"
                           description: Error ellipse semi-major axis, arcsec.
                         unc_b:
-                          type: number
+                          type:
+                            - number
+                            - "null"
                           description: Error ellipse semi-minor axis, arcsec.
                         unc_theta:
-                          type: number
+                          type:
+                            - number
+                            - "null"
                           description: Error ellipse position angle (E of N), deg.
                         elong:
                           type: number

--- a/tests/test_query_moving.py
+++ b/tests/test_query_moving.py
@@ -164,7 +164,7 @@ def test_status_job_id():
 
 
 def test_ephemeris_uncertainties_are_null():
-    # regression test for PR#xxxx
+    # regression test for #33
 
     # must be a target with undefined ephemeris uncertainties:
     q, queued = _query('108P', True, 'neat_palomar_tricam')

--- a/tests/test_query_moving.py
+++ b/tests/test_query_moving.py
@@ -45,7 +45,7 @@ TARGET_MATCHES = [
     ('skymapper', 'A/2017 U1', 2),
     ('neat_maui_geodss', '1', 12),
     ('neat_palomar_tricam', '(2) Juno', 9),
-    ('skymapper', '1I/`Oumuamua', 2)
+    ('skymapper', '1I/`Oumuamua', 2),
 ]
 
 
@@ -161,3 +161,15 @@ def test_status_job_id():
     data = res.json()
     assert data['job_id'] == q['job_id']
     assert data['status'][0]['execution_time'] is None
+
+
+def test_ephemeris_uncertainties_are_null():
+    # regression test for PR#xxxx
+
+    # must be a target with undefined ephemeris uncertainties:
+    q, queued = _query('108P', True, 'neat_palomar_tricam')
+
+    for caught in q["data"]:
+        assert caught["unc_a"] is None
+        assert caught["unc_b"] is None
+        assert caught["unc_theta"] is None


### PR DESCRIPTION
CATCH APIs errors when the uncertainty ellipse parameters are set to `None`:
```json
{
  "detail": "None is not of type 'number'\n\nFailed validating 'type' in schema['properties']['data']['items']['properties']['unc_a']:\n    {'description': 'Error ellipse semi-major axis, arcsec.',\n     'type': 'number'}\n\nOn instance['data'][0]['unc_a']:\n    None",
  "status": 500,
  "title": "Response body does not conform to specification",
  "type": "about:blank"
}
```

This PR sets these parameters to nullable and adds a regression test.  Also, some version bumps.